### PR TITLE
Fix reviewer to new team name

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -9,7 +9,7 @@
     ":enablePreCommit"
   ],
   "commitMessageAction": "Renovate:",
-  "reviewers": ["team:mirsg-rses"],
+  "reviewers": ["team:mirsg"],
   "pre-commit": {
     "fileMatch": ["precommit/mirsg-hooks.yaml"]
   },

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -7,7 +7,7 @@
     ":enablePreCommit"
   ],
   "commitMessageAction": "Renovate:",
-  "reviewers": ["team:mirsg-rses"],
+  "reviewers": ["team:mirsg"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Might mean it won't work until `renovate` updates is for everyone