### PR TITLE
Tag all commits to `main`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,9 +26,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: |-
-          python -m pip install pre-commit
-          pre-commit install
+        run: python -m pip install pre-commit
 
       - name: Run pre-commit
         run: pre-commit run --all-files --color always --verbose

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,0 +1,23 @@
+name: Bump Version Tag
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.64.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -8,20 +8,6 @@
   ],
   "commitMessageAction": "Renovate:",
   "reviewers": ["team:mirsg"],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Update pre-commit via hash for MIRSG hooks",
-      "currentValueTemplate": "main",
-      "datasourceTemplate": "git-refs",
-      "depNameTemplate": "mirsg-hooks",
-      "fileMatch": ["(^|/)\\.pre-commit-config\\.ya?ml$"],
-      "matchStrings": [
-        "https://github.com/UCL-MIRSG/\\.github\\s*rev:\\s['\"]?(?<currentDigest>.*?)['\"]?\\s*hooks:"
-      ],
-      "packageNameTemplate": "https://github.com/UCL-MIRSG/.github"
-    }
-  ],
   "packageRules": [
     {
       "description": "Automatically merge minor and patch-level updates",

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "schedule:monthly",
+    "schedule:weekdays",
     ":disableDependencyDashboard",
     ":enablePreCommit"
   ],


### PR DESCRIPTION
This is a much simpler approach, thank you @sfmig for the idea!

This will `push` a `tag` to `main`, every time something changes. So it should just be handled like a regular `pre-commit` hook.

I've restored the week daily schedule