### PR TITLE
Removing the config validation as it is really slow

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -33,10 +33,6 @@ repos:
     rev: v6.20.3
     hooks:
       - id: ansible-lint
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.22.0
-    hooks:
-      - id: renovate-config-validator
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
Might be worth having for repos like `XnatInstaller` @drmatthews, but if so, let's do it for that repo only. The installation step of this hook is slow. Useful for this repo, but maybe not otherwise?