### PR TITLE
Configure `ansible-lint` in `pre-commit` rather than file

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -33,6 +33,9 @@ repos:
     rev: v6.20.3
     hooks:
       - id: ansible-lint
+        args:
+         - --exclude=.github
+         - --warn-list=yaml[indentation]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
Related to UCL-MIRSG/Infrastructure#41, removes the need to have a config file in every repo