### PR TITLE
Add composite action 'molecule-test'

### DIFF
--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -1,0 +1,32 @@
+# Molecule Test
+
+This action can be used in the following manner:
+
+```yaml
+jobs:
+  molecule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run `molecule test`
+        uses: UCL-MIRSG/.github/actions/molecule-test@v.0.1.0
+```
+
+This will run the `default` scenario for your role. If you would like to specify a different
+scenario, you can specify this with the `scenario` input:
+
+```yaml
+jobs:
+  molecule:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        molecule_scenario:
+          - centos7
+          - rocky8
+    steps:
+      - name: Run `molecule test`
+        uses: UCL-MIRSG/.github/actions/molecule-test@v.0.1.0
+        with:
+          scenario: ${{ matrix.molecule_scenario }}
+```

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -8,11 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@v.0.1.0
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
 ```
 
-This will run the `default` scenario for your role. If you would like to specify a different
-scenario, you can specify this with the `scenario` input:
+where `x.y.z` is the `major.minor.patch` version of the action you would like to use.
+
+The above workflow will run the `default` scenario for your role. If you would like to
+specify a different scenario, you can do so with the `scenario` input:
 
 ```yaml
 jobs:
@@ -26,7 +28,7 @@ jobs:
           - rocky8
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@v0.21.0
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
         with:
           scenario: ${{ matrix.molecule_scenario }}
 ```

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -26,7 +26,7 @@ jobs:
           - rocky8
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@v.0.1.0
+        uses: UCL-MIRSG/.github/actions/molecule-test@v0.21.0
         with:
           scenario: ${{ matrix.molecule_scenario }}
 ```

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -1,0 +1,26 @@
+---
+name: Molecule Test
+description: Run `molecule test` on an Ansible role
+
+inputs:
+  scenario:
+    description: Name of the scenario to run the tests on
+    required: false
+    default: default
+
+runs:
+  using: composite
+  steps:
+    - name: Check out the codebase
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - name: Install test dependencies
+      run: |
+        sudo apt-get update && sudo apt-get -y install rsync
+        python3 -m pip install --upgrade pip
+        python3 -m pip install ansible molecule molecule-plugins[docker] docker requests
+    - name: Test with molecule
+      run: molecule test --scenario-name ${{ inputs.scenario }}

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -23,4 +23,4 @@ runs:
         python3 -m pip install --upgrade pip
         python3 -m pip install ansible molecule molecule-plugins[docker] docker requests
     - name: Test with molecule
-      run: molecule test --scenario-name ${{ inputs.scenario }}
+      run: molecule test --scenario-name  "${{ inputs.scenario }}"


### PR DESCRIPTION
- add a composite action that can be used for running `molecule test` in standalone Ansible roles
- takes a single input `scenario` that determines which scenario to run; defaults to `default`