### PR TITLE
Specify shell for molecule-test action

### DIFF
--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -18,9 +18,11 @@ runs:
       with:
         python-version: 3.11
     - name: Install test dependencies
+      shell: bash
       run: |
         sudo apt-get update && sudo apt-get -y install rsync
         python3 -m pip install --upgrade pip
         python3 -m pip install ansible molecule molecule-plugins[docker] docker requests
     - name: Test with molecule
+      shell: bash
       run: molecule test --scenario-name  "${{ inputs.scenario }}"


### PR DESCRIPTION
I didn't realise that you must specify `shell` for all `run` commands in a composite action

Otherwise the workflow using this action will fail with:
```
Error: UCL-MIRSG/.github/v0.23.0/actions/molecule-test/action.yml (Line: 20, Col: 7): Required property is missing: shell
```