### PR TITLE
Only `push` new `tag` on non-markdown changes

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "**/*"
+      - "!.github/**"
       - "!**/*.md"
 
 jobs:

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - '**/*'
-      - '!**/*.md'
+      - "**/*"
+      - "!**/*.md"
 
 jobs:
   tags:

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*'
+      - '!**/*.md'
 
 jobs:
   tags:


### PR DESCRIPTION
I'm not 100% sure if this will work, but let's give it a go. Again, this should reduce some tags. For example, UCL-MIRSG/.github#43 doesn't really need to bump tag.