### PR TITLE
Switch to `ruff-format` & specify `check=False`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.27.1
+    rev: 37.33.2
     hooks:
       - id: renovate-config-validator
         args: [renovate/default-config.json]
@@ -22,9 +22,10 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.27.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,7 @@ repos:
     rev: v0.1.0
     hooks:
       - id: ruff
-  - repo: https://github.com/psf/black
-    rev: 23.10.0
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.27.0
     hooks:

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -11,7 +11,7 @@ def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
     result = subprocess.run(
         shlex.split(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
-        check=True,
+        check=False,
     )
     return result.returncode
 

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -2,14 +2,17 @@
 import pathlib
 import subprocess
 import sys
+import shlex
 
 HERE = pathlib.Path(__file__).resolve()
 
 
 def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
-    cmd = ["pre-commit", "run", "--config", f"{cfg}", "--files"] + sys.argv[1:]
-    result = subprocess.run(cmd, check=True)
+    result = subprocess.run(
+        shlex.run(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
+        check=True,
+    )
     return result.returncode
 
 

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -11,7 +11,9 @@ def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
     result = subprocess.run(
         shlex.split(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
+        capture_output=True,
         check=True,
+        text=True,
     )
     return result.returncode
 

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -11,9 +11,7 @@ def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
     result = subprocess.run(
         shlex.split(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
-        capture_output=True,
         check=True,
-        text=True,
     )
     return result.returncode
 

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -10,7 +10,7 @@ HERE = pathlib.Path(__file__).resolve()
 def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
     result = subprocess.run(
-        shlex.run(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
+        shlex.split(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
         check=True,
     )
     return result.returncode

--- a/precommit/run-mirsg-hooks.py
+++ b/precommit/run-mirsg-hooks.py
@@ -2,7 +2,6 @@
 import pathlib
 import subprocess
 import sys
-import shlex
 
 HERE = pathlib.Path(__file__).resolve()
 
@@ -10,7 +9,14 @@ HERE = pathlib.Path(__file__).resolve()
 def main() -> int:
     cfg = HERE.parent / "mirsg-hooks.yaml"
     result = subprocess.run(
-        shlex.split(f"pre-commit run --config {cfg} --files {sys.argv[1:]}"),
+        [
+            "pre-commit",
+            "run",
+            "--config",
+            f"{cfg}",
+            "--files",
+        ]
+        + sys.argv[1:],
         check=False,
     )
     return result.returncode


### PR DESCRIPTION
`shelx.split` makes it a lot more readable. Also, revert #50 as it adds extra clutter. But we should specify `check` https://docs.astral.sh/ruff/rules/subprocess-run-without-check.