### PR TITLE
Test the linter on other OS

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    name: linting ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4


### PR DESCRIPTION
Wouldn't normally do this, but this local linter is essentially acting as a test for the GitHub Action.

I almost introduced the non-Windows compliant `shlex` library in #51 (thanks for spotting @p-j-smith). This will stop anything like that happening.