### PR TITLE
Only update branches when scheduled

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,14 +9,7 @@ on:
 
 jobs:
   linting:
-    name: linting ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,7 +9,14 @@ on:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    name: linting ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -4,7 +4,8 @@
     "config:base",
     "schedule:monthly",
     ":disableDependencyDashboard",
-    ":enablePreCommit"
+    ":enablePreCommit",
+    ":noUnscheduledUpdates"
   ],
   "commitMessageAction": "Renovate:",
   "reviewers": ["team:mirsg"],

--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -8,7 +8,6 @@
   ],
   "commitMessageAction": "Renovate:",
   "reviewers": ["team:mirsg"],
-  "schedule": ["* * 17 * *"],
   "packageRules": [
     {
       "description": "Automatically merge minor and patch-level updates",


### PR DESCRIPTION
https://docs.renovatebot.com/presets-default/#nounscheduledupdates I suspect this is the main problem in terms of minutes

Also removing the schedule, as not needed with the app disabled currently