### PR TITLE
Add a link to general MIRSG issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: General MIRSG issue
+    url: https://github.com/UCL-MIRSG/MIRSG/issues/new/choose
+    about: If your issue is a general MIRSG issue rather than this repo specific.


### PR DESCRIPTION
We should be putting general MIRSG issues at https://github.com/UCL-MIRSG/MIRSG, this easy link should hopefully make sure issues are made in the right place

+ trying out new feature https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser