### PR TITLE
Allows project-url as input to add-to-project action

### DIFF
--- a/.github/workflows/manage-projects.yml
+++ b/.github/workflows/manage-projects.yml
@@ -1,0 +1,15 @@
+name: Manage issues on the projects board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-issue-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UCL-MIRSG/.github/actions/add-to-project@v0.25.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          app-pem: ${{ secrets.APP_PEM }}

--- a/actions/add-to-project/README.md
+++ b/actions/add-to-project/README.md
@@ -11,6 +11,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           app-pem: ${{ secrets.APP_PEM }}
+          project-id: project_board_url # optional: defaults to the project board url
 ```
 
 where `x.y.z` is the `major.minor.patch` version of the action.
+where `project_board_url` is the url of the project board to add the issue to.

--- a/actions/add-to-project/README.md
+++ b/actions/add-to-project/README.md
@@ -11,7 +11,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           app-pem: ${{ secrets.APP_PEM }}
-          project-id: project_board_url # optional: defaults to the project board url
+          project-url: project_board_url # optional: defaults to https://github.com/orgs/UCL-MIRSG/projects/3
 ```
 
 where `x.y.z` is the `major.minor.patch` version of the action.

--- a/actions/add-to-project/README.md
+++ b/actions/add-to-project/README.md
@@ -1,6 +1,6 @@
 # add-to-project
 
-This action can be used in the following manner:
+This action can be used in the following manner to add issues to the [default MIRSG project board](https://github.com/orgs/UCL-MIRSG/projects/3):
 
 ```yaml
 jobs:
@@ -11,8 +11,20 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           app-pem: ${{ secrets.APP_PEM }}
-          project-url: project_board_url # optional: defaults to https://github.com/orgs/UCL-MIRSG/projects/3
 ```
 
-where `x.y.z` is the `major.minor.patch` version of the action.
-where `project_board_url` is the url of the project board to add the issue to.
+where `x.y.z` is the `major.minor.patch` version of the action. If a different project board is to be targeted, then the `project-url` input can be used and the above modified to:
+
+```yaml
+jobs:
+  add-issue-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UCL-MIRSG/.github/actions/add-to-project@vx.y.z
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          app-pem: ${{ secrets.APP_PEM }}
+          project-url: project_board_url
+```
+
+where `project_board_url` is the full URL of the project board to which the repository's issues should be added.

--- a/actions/add-to-project/action.yml
+++ b/actions/add-to-project/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Application private key
     required: true
 
+  project-url:
+    description: URL of the project board to add issues to
+    default: https://github.com/orgs/UCL-MIRSG/projects/3
+
 runs:
   using: composite
   steps:
@@ -23,5 +27,5 @@ runs:
     - name: Get project data
       uses: actions/add-to-project@v0.5.0
       with:
-        project-url: https://github.com/orgs/UCL-MIRSG/projects/3
+        project-url: ${{ input.project-url }}
         github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Following @paddyroddy's idea, this PR modifies the add-to-project composite action so that it can optionally take in a project board URL as a target for where issues should be added. By default it will add to the MIRSG project board, but if provided can add issues to alternative locations (e.g. a project specific board).

In addition, this PR also enables the add-to-project workflow for this repo, so that issues created are added to the MIRSG project board by default.