### PR TITLE
Also exclude `docker-compose.yml`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -34,8 +34,8 @@ repos:
     hooks:
       - id: ansible-lint
         args:
-          - --exclude=.github
-          - --warn-list=yaml[indentation]
+          - --exclude .github docker-compose.yml
+          - --warn-list yaml[indentation]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
Have verified this syntax running this locally
```sh
ansible-lint --exclude .github docker-compose.yml --warn-list "yaml[indentation]"
```
Relevant for SRR