### PR TITLE
Fix ansible lint bug

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -34,8 +34,9 @@ repos:
     hooks:
       - id: ansible-lint
         args:
-          - --exclude .github docker-compose.yml
-          - --warn-list yaml[indentation]
+          - --exclude=.github
+          - --exclude=docker-compose.yml
+          - --warn-list=yaml[indentation]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
#68 didn't work as expected, tested on another repo
```
load-failure[not-found]: File or directory not found.
--exclude .github docker-compose.yml:1

load-failure[filenotfounderror]: [Errno 2] No such file or directory: '/Users/paddy/arc/srr/--exclude .github docker-compose.yml'
--exclude .github docker-compose.yml:1 None

load-failure[not-found]: File or directory not found.
--warn-list yaml:1


                       Rule Violation Summary
 count tag                             profile rule associated tags
     1 load-failure[filenotfounderror] min     core, unskippable
     2 load-failure[not-found]         min     core, unskippable
```
Turns out I should have run `./precommit/run-mirsg-hooks.py` locally to check this, as the CI had passed