### PR TITLE
Add `docker` to `pre-commit` & ignore `apt-get install`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -11,7 +11,8 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-        args: [--fix=lf]
+        args:
+          - --fix=lf
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4
@@ -41,3 +42,9 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.12.0.3
+    hooks:
+      - id: hadolint
+        args:
+          - --ignore=DL3008


### PR DESCRIPTION
Feels like we currently use (and expect to more in the future) `docker` in our repos, so probably worth benefiting from it in the master hook

Rule explanation https://github.com/hadolint/hadolint/wiki/DL3008