### PR TITLE
Remove `yaml[indentation]` warning as it is unnecessary

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -37,7 +37,6 @@ repos:
         args:
           - --exclude=.github
           - --exclude=docker-compose.yml
-          - --warn-list=yaml[indentation]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
I was looking at the `ansible-lint` docs and noticed this bit https://ansible.readthedocs.io/projects/lint/rules/yaml where it explicitly talks about agreement with `prettier`. So we don't need to turn this rule off.

This came about because @p-j-smith had conflicts in #38 and wasn't sure what to do. This was a quick fix, but long-term I think it's useful to keep as many rules as possible.

The exact issue discussed here ansible/ansible-lint#2678 😆