### PR TITLE
Add `checkout_path` input to the `molecule-test` action

### DIFF
--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -32,3 +32,18 @@ jobs:
         with:
           scenario: ${{ matrix.molecule_scenario }}
 ```
+
+If you are testing an Ansible Collection, Molecule requires your repository to be in a specific
+path - `ansible_collections/<namespace>/<collection nane>`. You can set the checkout path
+using the `checkout_path` input:
+
+```yaml
+jobs:
+  molecule:
+    runs-on: ubuntu-latest        
+    steps:
+      - name: Run `molecule test`
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
+        with:
+          checkout_path: ansible_collections/my_namespace/my_collection
+```

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -34,13 +34,13 @@ jobs:
 ```
 
 If you are testing an Ansible Collection, Molecule requires your repository to be in a specific
-path - `ansible_collections/<namespace>/<collection nane>`. You can set the checkout path
+path - `ansible_collections/<namespace>/<collection name>`. You can set the checkout path
 using the `checkout_path` input:
 
 ```yaml
 jobs:
   molecule:
-    runs-on: ubuntu-latest        
+    runs-on: ubuntu-latest
     steps:
       - name: Run `molecule test`
         uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -7,12 +7,18 @@ inputs:
     description: Name of the scenario to run the tests on
     required: false
     default: default
+  checkout_path:
+    description: Path to use when checking out the repository
+    required: false
+    default: ./
 
 runs:
   using: composite
   steps:
     - name: Check out the codebase
       uses: actions/checkout@v4
+      with:
+        path: "${{ inputs.checkout_path }}"
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -25,4 +31,6 @@ runs:
         python3 -m pip install ansible molecule molecule-plugins[docker] docker requests
     - name: Test with molecule
       shell: bash
-      run: molecule test --scenario-name  "${{ inputs.scenario }}"
+      run: |
+        cd "${{ inputs.checkout_path }}"
+        molecule test --scenario-name  "${{ inputs.scenario }}"


### PR DESCRIPTION
When testing Ansible Collections, Molecule requires that the collection is in a specific path (`ansible_collections/<namespace>/<collection_name>`). To allow testing collections with the `molecule-test` actions, a `checkout_path` input has been added.