### PR TITLE
Fix testing Ansible Collections with the `molecule-test` action

### DIFF
--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -34,8 +34,12 @@ jobs:
 ```
 
 If you are testing an Ansible Collection, Molecule requires your repository to be in a specific
-path - `ansible_collections/<namespace>/<collection name>`. You can set the checkout path
-using the `checkout_path` input:
+path - `ansible_collections/<namespace>/<collection name>`. Another requirement is that your
+Molecule configuration is not at the top-level of the repository - you should put it in e.g.
+a `tests/` directory.
+
+To use this action to test your Collection, you will need to specify a `checkout_path` and
+`tests/path`:
 
 ```yaml
 jobs:
@@ -46,4 +50,8 @@ jobs:
         uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
         with:
           checkout_path: ansible_collections/my_namespace/my_collection
+          tests_path: ansible_collections/my_namespace/my_collection/tests
 ```
+
+Note, the `tests_path` is relative to the `$GITHUB_WORKSPACE` path, not to the
+`checkout_path`.

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Path to use when checking out the repository
     required: false
     default: ./
+  tests_path:
+    description: Change to this directory before running `molecule test`
+    required: false
+    default: ./
 
 runs:
   using: composite
@@ -32,5 +36,5 @@ runs:
     - name: Test with molecule
       shell: bash
       run: |
-        cd "${{ inputs.checkout_path }}"
+        cd "${{ inputs.tests_path }}"
         molecule test --scenario-name  "${{ inputs.scenario }}"


### PR DESCRIPTION
#80 added a `checkout_path` input to the `molecule-test` action. However, the tests for the Collection cannot be in the top-level of the repository, and so the `checkout_path` is different to the path form which `molecule test` must be run. Currently, this action [fails when being used to test a Collection](https://github.com/UCL-MIRSG/ansible-collection-infra/actions/runs/7018506811/job/19094047384?pr=5#step:2:314).

- add a `test_path` input to the `molecule-test` action
- add instructions to the action README on how to use the action to test a Collection