### PR TITLE
Improve tagging workflow for this repo

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -6,10 +6,13 @@ on:
       - main
     paths:
       - "**/*"
-      - "!.github/**"
-      - "!.pre-commit-config.yaml"
       - "!**/*.json"
+      - "!**/*.json5"
       - "!**/*.md"
+      - "!.github/**"
+      - "!.gitignore"
+      - "!.pre-commit-config.yaml"
+  workflow_dispatch:
 
 jobs:
   tags:
@@ -23,7 +26,24 @@ jobs:
           fetch-depth: 0
 
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.67.0
+        id: bump-version
+        uses: anothrNick/github-tag-action@a2c70ae13a881faf2b4953baaa9e49731997ab36 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
+
+      - name: Extract major tag
+        id: extract-major
+        run: >-
+          echo major_tag=$(echo ${{ steps.bump-version.outputs.new_tag }} |
+          cut -d'.' -f1) >> $GITHUB_OUTPUT
+
+      # this is done manually as need a non-annotated tag
+      # TODO: replace with https://github.com/actions/publish-action
+      - name: Update major tag
+        run: |-
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag --force ${{ steps.extract-major.outputs.major_tag }} \
+          ${{ steps.bump-version.outputs.new_tag }}
+          git push origin ${{ steps.extract-major.outputs.major_tag }} --force

--- a/actions/add-to-project/README.md
+++ b/actions/add-to-project/README.md
@@ -1,30 +1,34 @@
 # add-to-project
 
-This action can be used in the following manner to add issues to the [default MIRSG project board](https://github.com/orgs/UCL-MIRSG/projects/3):
+This action can be used in the following manner to add issues to the [default
+MIRSG project board](https://github.com/orgs/UCL-MIRSG/projects/3):
 
 ```yaml
 jobs:
   add-issue-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/add-to-project@vx.y.z
+      - uses: UCL-MIRSG/.github/actions/add-to-project@vx
         with:
           app-id: ${{ secrets.APP_ID }}
           app-pem: ${{ secrets.APP_PEM }}
 ```
 
-where `x.y.z` is the `major.minor.patch` version of the action. If a different project board is to be targeted, then the `project-url` input can be used and the above modified to:
+where `x` is the `major` version of the action. If a different project board is
+to be targeted, then the `project-url` input can be used and the above modified
+to:
 
 ```yaml
 jobs:
   add-issue-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/add-to-project@vx.y.z
+      - uses: UCL-MIRSG/.github/actions/add-to-project@vx
         with:
           app-id: ${{ secrets.APP_ID }}
           app-pem: ${{ secrets.APP_PEM }}
           project-url: project_board_url
 ```
 
-where `project_board_url` is the full URL of the project board to which the repository's issues should be added.
+where `project_board_url` is the full URL of the project board to which the
+repository's issues should be added.

--- a/actions/linting/README.md
+++ b/actions/linting/README.md
@@ -7,20 +7,20 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/linting@vx.y.z
+      - uses: UCL-MIRSG/.github/actions/linting@vx
         with:
           pre-commit-config: ./.pre-commit-config.yaml
 ```
 
-where `x.y.z` is the `major.minor.patch` version of the action. If the linting
-also requires [Ansible](https://www.ansible.com) then modify the above to:
+where `x` is the `major` version of the action. If the linting also requires
+[Ansible](https://www.ansible.com) then modify the above to:
 
 ```yaml
 jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/linting@vx.y.z
+      - uses: UCL-MIRSG/.github/actions/linting@vx
         with:
           ansible-roles-config: ./requirements.yml
           pre-commit-config: ./.pre-commit-config.yaml

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx
 ```
 
-where `x.y.z` is the `major.minor.patch` version of the action you would like to use.
+where `x` is the `major` version of the action you would like to use.
 
-The above workflow will run the `default` scenario for your role. If you would like to
-specify a different scenario, you can do so with the `scenario` input:
+The above workflow will run the `default` scenario for your role. If you would
+like to specify a different scenario, you can do so with the `scenario` input:
 
 ```yaml
 jobs:
@@ -28,18 +28,18 @@ jobs:
           - rocky8
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx
         with:
           scenario: ${{ matrix.molecule_scenario }}
 ```
 
-If you are testing an Ansible Collection, Molecule requires your repository to be in a specific
-path - `ansible_collections/<namespace>/<collection name>`. Another requirement is that your
-Molecule configuration is not at the top-level of the repository - you should put it in e.g.
-a `tests/` directory.
+If you are testing an Ansible Collection, Molecule requires your repository to
+be in a specific path - `ansible_collections/<namespace>/<collection name>`.
+Another requirement is that your Molecule configuration is not at the top-level
+of the repository - you should put it in e.g. a `tests/` directory.
 
-To use this action to test your Collection, you will need to specify a `checkout_path` and
-`tests/path`:
+To use this action to test your Collection, you will need to specify a
+`checkout_path` and `tests/path`:
 
 ```yaml
 jobs:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run `molecule test`
-        uses: UCL-MIRSG/.github/actions/molecule-test@vx.y.z
+        uses: UCL-MIRSG/.github/actions/molecule-test@vx
         with:
           checkout_path: ansible_collections/my_namespace/my_collection
           tests_path: ansible_collections/my_namespace/my_collection/tests


### PR DESCRIPTION
Fixes #74. I'm using this in https://github.com/paddyroddy/.github. Has the advantage that we can refer to actions as, e.g. `v0`. But `pre-commit` hooks to `v0.40.0` (which is what `pre-commit autoupdate` expects).