### PR TITLE
Add `yamllint` to hooks

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -1,5 +1,20 @@
 exclude: .crt$
 repos:
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.33.0
+    hooks:
+      - id: yamllint
+        args:
+          - >-
+            --config-data={
+              extends: default,
+              rules: {
+                comments: {
+                  min-spaces-from-content: 1
+                }
+              }
+            }
+          - --strict
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.12.0.3
     hooks:


### PR DESCRIPTION
This will cause breakages next month, as most repos probably aren't following `yamllint` best practices. We can then either fix them, or ignore with a local file.

Taken from https://github.com/paddyroddy/.github/blob/main/precommit/general/general-hooks.yml