### PR TITLE
Exclude templated scripts

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -68,6 +68,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
+        exclude: \.j2$
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: mixed-line-ending

--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -68,7 +68,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
-        exclude: \.j2$
+        exclude: .j2$
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: mixed-line-ending


### PR DESCRIPTION
Exclude templated scripts when running `check-shebang-scripts-are-executable` hook to avoid messages like:

```
roles/postgresql/templates/run_db_backup.sh.j2: has a shebang but is not marked executable!
  If it is supposed to be executable, try: `chmod +x roles/postgresql/templates/run_db_backup.sh.j2`
  If on Windows, you may also need to: `git add --chmod=+x roles/postgresql/templates/run_db_backup.sh.j2`
  If it not supposed to be executable, double-check its shebang is wanted.
```