### PR TITLE
Turn off strict `yamllint`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -12,10 +12,12 @@ repos:
               rules: {
                 comments: {
                   min-spaces-from-content: 1
+                },
+                line-length: {
+                  level: warning
                 }
               }
             }
-          - --strict
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.12.0.3
     hooks:


### PR DESCRIPTION
And reduce line length complaints to warning. Sad times, but I think this will be too hard to fix in a lot of cases.