### PR TITLE
Add more `yamllint`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -10,11 +10,41 @@ repos:
             --config-data={
               extends: default,
               rules: {
+                anchors: enable,
+                braces: {
+                  forbid: true
+                },
+                brackets: {
+                  forbid: true
+                },
+                colons: enable,
+                commas: enable,
                 comments: {
                   min-spaces-from-content: 1
                 },
+                comments-indentation: enable,
+                document-end: disable,
+                document-start: enable,
+                empty-lines: enable,
+                empty-values: disable,
+                float-values: enable,
+                hyphens: enable,
+                indentation: enable,
+                key-duplicates: enable,
+                key-ordering: disable,
                 line-length: {
-                  level: warning
+                  max: 160
+                },
+                new-line-at-end-of-file: enable,
+                new-lines: enable,
+                octal-values: enable,
+                quoted-strings: {
+                  quote-type: double,
+                  required: only-when-needed
+                },
+                trailing-spaces: enable,
+                truthy: {
+                  check-keys: false
                 }
               }
             }


### PR DESCRIPTION
See an explanation of what the different rules do here https://yamllint.readthedocs.io/en/stable/rules.html. I was fiddling in a previous PR, and figured we could use `yamllint` more to enforce consistency and reduce bugs - whilst hopefully not being too annoying. I've tested this myself on my own repos, and think the subset I have aren't too bad. Will explain a few differences in comments.