### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -2,7 +2,7 @@
 name: Service Request
 description: A service request to the MIRSG team
 title: "📥 [REQUEST]: "
-labels: ["request"] # yamllint disable-line
+labels: ["request"] # yamllint disable-line rule:quoted-strings rule:brackets
 body:
   - type: textarea
     id: request-description

--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -2,7 +2,7 @@
 name: Service Request
 description: A service request to the MIRSG team
 title: "📥 [REQUEST]: "
-labels: ["request"]
+labels: ["request"] # yamllint disable-line
 body:
   - type: textarea
     id: request-description

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - "renovate/**"
+      - renovate/**
   pull_request:
     types:
       - opened

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.43.0
+    rev: v0.48.0
     hooks:
       - id: mirsg-hooks
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 37.44.0
+    rev: 37.233.1
     hooks:
       - id: renovate-config-validator
         args:

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -23,7 +23,7 @@ runs:
         path: |-
           ~/.ansible
           ~/.cache/pre-commit
-        key: "\
+        key: "\  # yamllint disable-line rule:quoted-strings
           cache-\
           ${{ hashFiles(inputs.ansible-roles-config) }}-\
           ${{ hashFiles(inputs.pre-commit-config) }}\

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Check out the codebase
       uses: actions/checkout@v4
       with:
-        path: "${{ inputs.checkout_path }}"
+        path: ${{ inputs.checkout_path }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -12,10 +12,10 @@ repos:
               rules: {
                 anchors: enable,
                 braces: {
-                  forbid: true
+                  forbid: non-empty
                 },
                 brackets: {
-                  forbid: true
+                  forbid: non-empty
                 },
                 colons: enable,
                 commas: enable,


### PR DESCRIPTION
- update to `v0.48.0` of the MIRSG pre-commit hook
- update to `v37.233.1` of the pre-commit hook
- make the updated versions of the linters happy