### PR TITLE
Auto-update `dockerfile`

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -23,7 +23,7 @@
     {
       "description": "Automatically merge, minor and patch-level updates",
       "automerge": true,
-      "matchManagers": ["github-actions", "pre-commit"],
+      "matchManagers": ["dockerfile", "github-actions", "pre-commit"],
       "matchUpdateTypes": ["digest", "minor", "patch"]
     },
     {


### PR DESCRIPTION
Now that we are using hashed versions, this would greatly reduce noise and should be safe, i.e. UCL-MIRSG/ecst-2-bulk-uploade#21. Manager config: https://docs.renovatebot.com/modules/manager/dockerfile.