### PR TITLE
Remove `:noUnscheduledUpdates`

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -9,7 +9,6 @@
     ":disableDependencyDashboard",
     ":enablePreCommit",
     ":label(renovate)",
-    ":noUnscheduledUpdates",
     ":prHourlyLimitNone"
   ],
   "commitMessageAction": "Renovate:",


### PR DESCRIPTION
There seems to be a bug in @renovatebot renovatebot/renovate#24275. This may increase CI use (although we're still setting a `schedule` and an `automergeSchedule` so it shouldn't be much). This PR should fix blocked @renovatebot updates.