### PR TITLE
Inherit from ARC Renovate config

### DIFF
--- a/renovate/default-config.json
+++ b/renovate/default-config.json
@@ -1,54 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    "schedule:automergeWeekdays",
-    "schedule:monthly",
-    ":assignAndReview(team:mirsg)",
-    ":automergeBranch",
-    ":disableDependencyDashboard",
-    ":enablePreCommit",
-    ":label(renovate)",
-    ":noUnscheduledUpdates",
-    ":prHourlyLimitNone"
+    "github>UCL-ARC/.github//renovate/default-config.json",
+    ":assignAndReview(team:mirsg)"
   ],
-  "commitMessageAction": "Renovate:",
   "gradle": {
     "enabled": false
   },
   "maven": {
     "enabled": false
-  },
-  "packageRules": [
-    {
-      "description": "Automatically merge, minor and patch-level updates",
-      "automerge": true,
-      "matchManagers": ["github-actions", "pre-commit"],
-      "matchUpdateTypes": ["digest", "minor", "patch"]
-    },
-    {
-      "description": "Shorten commit titles",
-      "commitMessageTopic": "{{depName}}",
-      "matchManagers": ["github-actions", "pre-commit"]
-    },
-    {
-      "description": "Combine action artefact updates together",
-      "groupName": "artefacts",
-      "matchDepNames": ["actions/download-artifact", "actions/upload-artifact"]
-    },
-    {
-      "description": "Only allow major updates",
-      "enabled": false,
-      "matchDepNames": ["renovatebot/pre-commit-hooks"],
-      "matchUpdateTypes": ["minor", "patch", "pin"]
-    },
-    {
-      "description": "Support loose versioning",
-      "matchDepNames": [
-        "cmhughes/latexindent.pl",
-        "shellcheck-py/shellcheck-py"
-      ],
-      "versioning": "loose"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
I've been keeping the default @renovatebot config here and https://github.com/UCL-ARC/.github in sync, but this doesn't make much sense. So I'm inheriting from the ARC config here - much like we inherit from the MIRSG one for other repos - and only included the differences in the default config.