### PR TITLE
Add `markdownlint`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -75,6 +75,13 @@ repos:
       - id: typos
         args:
           - --force-exclude
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.39.0
+    hooks:
+      - id: markdownlint-fix
+        args:
+          - --dot
+          - --fix
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
Fixes #89. Unfortunately, it is not possible to do the equivalent with [config options for yamllint rules](https://github.com/UCL-MIRSG/.github/blob/72c4affd9931cccb8fc816a79047ad201b933dcc/precommit/mirsg-hooks.yaml#L4-L50) - see issue here for details, igorshubovych/markdownlint-cli#452.

For issues with tables and/or code blocks, you can do the following https://github.com/UCL-MIRSG/UCLH-MPBE-SRR-XNAT/blob/8fac05d880f829afe16743e304d1a312bcd7fd1d/.markdownlint.yaml#L1-L3.