### PR TITLE
Remove duplicate `fix` flag

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -81,7 +81,6 @@ repos:
       - id: markdownlint-fix
         args:
           - --dot
-          - --fix
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
Forgot that `markdownlint-fix` runs `markdownlint --fix`