### PR TITLE
Specify Ansible version

### DIFF
--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -55,3 +55,6 @@ jobs:
 
 Note, the `tests_path` is relative to the `$GITHUB_WORKSPACE` path, not to the
 `checkout_path`.
+
+If one requires a specific version of Ansible, then use the `ansible_version`
+argument, i.e. `ansible_version: 10.0.0`.

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: Change to this directory before running `molecule test`
     required: false
     default: ./
+  ansible_version:
+    description: Version of Ansible to use
+    default: latest
 
 runs:
   using: composite
@@ -37,7 +40,18 @@ runs:
         sudo apt-get update && sudo apt-get -y install rsync
         python3 -m pip install --upgrade pip
         python3 -m pip install \
-        ansible molecule molecule-plugins[docker] docker requests
+        molecule molecule-plugins[docker] docker requests
+
+    - name: Install Ansible ${{ inputs.ansible_version }}
+      if: ${{ inputs.ansible_version != 'latest' }}
+      shell: bash
+      run: python -m pip install ansible==${{ inputs.ansible_version }}
+
+    - name: Install Ansible latest version
+      if: ${{ inputs.ansible_version == 'latest' }}
+      shell: bash
+      run: python -m pip install ansible
+
     - name: Test with molecule
       shell: bash
       run: |-


### PR DESCRIPTION
There appears to be changes in `10.0.0` that have broken the collection, this will give us the option to (temporarily) pin the version.