### PR TITLE
Add actionlint pre-commit hook to MIRSG meta hook

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -129,3 +129,7 @@ repos:
         args:
           - --external-sources
           - --shell=bash
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
Fixes #125 

- run [`actionlint`](https://github.com/rhysd/actionlint/tree/main) on GitHub workflows as part of the mirsg pre-commit hook