### PR TITLE
Comment out `crate-ci/typos`

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -69,14 +69,14 @@ repos:
           - --exit-non-zero-on-fix
           - --fix
       - id: ruff-format
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.24.3
-    hooks:
-      - id: typos
-        args:
-          - --force-exclude
-          - --hidden
-          - --locale=en-gb
+  # - repo: https://github.com/crate-ci/typos
+  #   rev: v1.24.3
+  #   hooks:
+  #     - id: typos
+  #       args:
+  #         - --force-exclude
+  #         - --hidden
+  #         - --locale=en-gb
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:


### PR DESCRIPTION
A recent change has meant the number of false positives had grown massively. I'm now debating full removal of this from the global `pre-commit` hook. For now I'll comment it out.