### PR TITLE
Restore/update `typos` and turn off British spelling

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -69,14 +69,13 @@ repos:
           - --exit-non-zero-on-fix
           - --fix
       - id: ruff-format
-  # - repo: https://github.com/crate-ci/typos
-  #   rev: v1.24.3
-  #   hooks:
-  #     - id: typos
-  #       args:
-  #         - --force-exclude
-  #         - --hidden
-  #         - --locale=en-gb
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.25.0
+    hooks:
+      - id: typos
+        args:
+          - --force-exclude
+          - --hidden
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:


### PR DESCRIPTION
`typos` has generally got better at detecting Americanisms, and hence is causing too much noise with complaining about spelling. Restoring it now but turning off British spelling.