### PR TITLE
Expand default to link checker and exclude project link

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -19,3 +19,8 @@ jobs:
       - uses: ./actions/links
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          lychee-args: >-
+            --exclude https://github.com/orgs/UCL-MIRSG/projects/3
+            --no-progress
+            --verbose
+            .

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -19,8 +19,6 @@ jobs:
       - uses: ./actions/links
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          lychee-args: >-
-            --exclude https://github.com/orgs/UCL-MIRSG/projects/3
-            --no-progress
-            --verbose
-            .
+          lychee-args:
+            --no-progress --verbose . --exclude
+            https://github.com/orgs/UCL-MIRSG/projects/3

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -11,8 +11,7 @@ inputs:
     description:
       Arguments to pass to lychee
       (https://github.com/lycheeverse/lychee#commandline-parameters)
-    default:
-      --base . --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst'
+    default: --verbose --no-progress .
 
 runs:
   using: composite


### PR DESCRIPTION
Discovered in #132, related to https://github.com/lycheeverse/lychee-action/issues/89.

We have two options
- Exclude project board
- Create a custom token to include project board (I think)

I've gone with the former as it's much simpler.