### PR TITLE
Add `pre-commit-ci` action to autofix

### DIFF
--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -60,3 +60,6 @@ runs:
     - name: Run pre-commit
       shell: bash
       run: pre-commit run --all-files --color always --verbose
+
+    - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
+      if: always()


### PR DESCRIPTION
Adds https://github.com/pre-commit-ci/lite-action to auto fix linting changes where possible. I've already installed the app org-wide.