### PR TITLE
Only run Safe-Settings stuff in related changes

### DIFF
--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
-      - renovate/**
   pull_request:
+    paths:
+      - safe-settings/**
+      - .github/workflows/safe-settings.yaml
   schedule:
     - cron: 0 */4 * * *
   workflow_dispatch: {}


### PR DESCRIPTION
The recent @renovatebot changes failed and worked if you ran them again. Not entirely sure why, but I think this is a safe change which should avoid erroneous failures.