### PR TITLE
Disable both `wrapper` via @renovatebot

### DIFF
--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -8,7 +8,13 @@
   gradle: {
     enabled: false,
   },
+  "gradle-wrapper": {
+    enabled: false,
+  },
   maven: {
+    enabled: false,
+  },
+  "maven-wrapper": {
     enabled: false,
   },
 }


### PR DESCRIPTION
I don't really know what these do but I spotted the changes elsewhere and figured it might be a good idea. Let me know what you think.

- https://docs.renovatebot.com/modules/manager/gradle-wrapper/
- https://docs.renovatebot.com/modules/manager/maven-wrapper/