### PR TITLE
Change token to app based to link check private repos

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: ./actions/links
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.LINK_APP_ID }}
+          app-pem: ${{ secrets.LINK_APP_PEM }}
           lychee-args:
             --no-progress --verbose . --exclude
             https://github.com/orgs/UCL-MIRSG/projects/3

--- a/actions/links/README.md
+++ b/actions/links/README.md
@@ -10,7 +10,8 @@ jobs:
     steps:
       - uses: UCL-MIRSG/.github/actions/links@vx
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.LINK_APP_ID }}
+          app-pem: ${{ secrets.LINK_APP_PEM }}
 ```
 
 where `x` is the `major` version of the action. If custom link checking is
@@ -23,7 +24,8 @@ jobs:
     steps:
       - uses: UCL-MIRSG/.github/actions/linting@vx
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.LINK_APP_ID }}
+          app-pem: ${{ secrets.LINK_APP_PEM }}
           lychee-args:
             --base . --verbose --no-progress './**/*.md' './**/*.html'
             './**/*.rst'

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -3,8 +3,12 @@ name: Links
 description: Checks the links in a repo work
 
 inputs:
-  github-token:
-    description: GitHub token
+  app-id:
+    description: Application ID
+    required: true
+
+  app-pem:
+    description: Application private key
     required: true
 
   lychee-args:
@@ -19,9 +23,16 @@ runs:
     - name: Checkout source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+    - name: Generate token
+      id: generate-token
+      uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.app-pem }}
+
     - name: Check links
       uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2
       with:
         args: ${{ inputs.lychee-args }}
         failIfEmpty: false
-        token: ${{ inputs.github-token }}
+        token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Currently, the link checking app `lychee` cannot access private repos for links. I've created an app which had the correct permissions to access these. See https://github.com/lycheeverse/lychee-action/issues/89.