### PR TITLE
Exclude TSV from tab hook

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -89,6 +89,7 @@ repos:
     rev: v1.5.5
     hooks:
       - id: forbid-tabs
+        exclude: .tsv$
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:


### PR DESCRIPTION
Noticed there were TSV files in https://github.com/UCL-MIRSG/omero-bulk-import so it makes sense to exclude them generally.