### PR TITLE
Also group `digest` updates

### DIFF
--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -3,6 +3,7 @@
   extends: [
     "github>UCL-ARC/.github//renovate/default-config.json",
     ":assignAndReview(team:mirsg)",
+    "group:allDigest",
     "group:allNonMajor",
   ],
   gradle: {


### PR DESCRIPTION
The aim was to cut down on the number of PRs. I'm hesitant to use the [group:all as major updates might get hidden](https://docs.renovatebot.com/presets-group/#groupall). I hadn't noticed that [group:allNonMajor doesn't include digest updates](https://github.com/renovatebot/renovate/issues/13864), but we can separately combine `digest` updates, so we'll reduce the number of PRs.