### PR TITLE
Add minimum release age for minor/major XNAT updates

### DIFF
--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -27,26 +27,6 @@
       matchDepNames: ["org.apache.tomcat:tomcat"],
     },
     {
-      description: "Update XNAT and associated plugins simultaneously immediately",
-      groupName: "xnat",
-      matchDepNames: [
-        "icrimaginginformatics/ohif-viewer-xnat-plugin",
-        "NrgXnat/xnat-pipeline-engine",
-        "VUIIS/dax",
-        "xnatdev/container-service",
-        "xnatdev/xnat-image-viewer-plugin",
-        "xnatdev/xnat-web",
-        "xnatdev/xsync",
-        "xnatx/datasets-plugin",
-        "xnatx/ldap-auth-plugin",
-        "xnatx/ml-plugin",
-        "xnatx/xnatx-batch-launch-plugin",
-        "xnatx/xnatx-dxm-settings-plugin",
-      ],
-      matchUpdateTypes: ["patch"],
-      versioning: "loose",
-    },
-    {
       description: "Update XNAT and associated plugins simultaneously delayed",
       groupName: "xnat",
       matchDepNames: [
@@ -64,8 +44,7 @@
         "xnatx/xnatx-dxm-settings-plugin",
       ],
       versioning: "loose",
-      matchUpdateTypes: ["major", "minor"],
-      minimumReleaseAge: "90 days",
+      minimumReleaseAge: "7 days",
     },
   ],
 }

--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -27,7 +27,27 @@
       matchDepNames: ["org.apache.tomcat:tomcat"],
     },
     {
-      description: "Update XNAT and associated plugins simultaneously",
+      description: "Update XNAT and associated plugins simultaneously immediately",
+      groupName: "xnat",
+      matchDepNames: [
+        "icrimaginginformatics/ohif-viewer-xnat-plugin",
+        "NrgXnat/xnat-pipeline-engine",
+        "VUIIS/dax",
+        "xnatdev/container-service",
+        "xnatdev/xnat-image-viewer-plugin",
+        "xnatdev/xnat-web",
+        "xnatdev/xsync",
+        "xnatx/datasets-plugin",
+        "xnatx/ldap-auth-plugin",
+        "xnatx/ml-plugin",
+        "xnatx/xnatx-batch-launch-plugin",
+        "xnatx/xnatx-dxm-settings-plugin",
+      ],
+      matchUpdateTypes: ["patch"],
+      versioning: "loose",
+    },
+    {
+      description: "Update XNAT and associated plugins simultaneously delayed",
       groupName: "xnat",
       matchDepNames: [
         "icrimaginginformatics/ohif-viewer-xnat-plugin",
@@ -44,6 +64,8 @@
         "xnatx/xnatx-dxm-settings-plugin",
       ],
       versioning: "loose",
+      matchUpdateTypes: ["major", "minor"],
+      minimumReleaseAge: "90 days",
     },
   ],
 }

--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -24,12 +24,12 @@
     {
       description: "Check Maven Central for updates to Tomcat 9",
       allowedVersions: "<10",
-      matchPackageNames: ["org.apache.tomcat:tomcat"],
+      matchDepNames: ["org.apache.tomcat:tomcat"],
     },
     {
       description: "Update XNAT and associated plugins simultaneously",
       groupName: "xnat",
-      matchPackageNames: [
+      matchDepNames: [
         "icrimaginginformatics/ohif-viewer-xnat-plugin",
         "NrgXnat/xnat-pipeline-engine",
         "VUIIS/dax",

--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -27,7 +27,7 @@
       matchDepNames: ["org.apache.tomcat:tomcat"],
     },
     {
-      description: "Update XNAT and associated plugins simultaneously delayed",
+      description: "Update XNAT and associated plugins simultaneously",
       groupName: "xnat",
       matchDepNames: [
         "icrimaginginformatics/ohif-viewer-xnat-plugin",


### PR DESCRIPTION
As discussed on Tuesday, @drmatthews mentioned 3 months does this sound correct?

I have changed references to [matchPackageNames](https://docs.renovatebot.com/configuration-options/#matchpackagenames) to [matchDepNames](https://docs.renovatebot.com/configuration-options/#matchdepnames) mainly for consistency. But we're also using [depNameTemplate](https://github.com/UCL-MIRSG/ansible-collection-infra/blob/97ae7debbe715cef32c1c54d4b4147037cb64be4/.renovaterc.json5#L27) so it really does make sense to use `depName`. They functionality equivalent (almost) all the time? At least I've not seen one yet where they are different.

Do we want to do anything similar for `tomcat`?