### PR TITLE
Enforce checking for large files

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -110,6 +110,8 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        args:
+          - --enforce-all
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-merge-conflict


### PR DESCRIPTION
We can always exclude things as-and-when we go. What do people think?