### PR TITLE
Allow @UCL-MIRSG/mirsg to skip status checks

### DIFF
--- a/safe-settings/suborgs/rulesets.yaml
+++ b/safe-settings/suborgs/rulesets.yaml
@@ -48,6 +48,11 @@ rulesets:
     target: branch
     enforcement: active
 
+    bypass_actors:
+      - actor_id: 5 # repository admin
+        actor_type: RepositoryRole
+        bypass_mode: pull_request
+
     conditions:
       ref_name:
         include:


### PR DESCRIPTION
**Note, this should be used responsibly.**

This allows one to override a ruleset in a PR in the case that a status check is failing for a known reason. For example, https://github.com/UCL-MIRSG/xnat-aws/pull/126 was failing, but I have separately raised https://github.com/UCL-MIRSG/xnat-aws/pull/127 to fix it. In this case, it is fine to merge the initial PR.

![image](https://github.com/user-attachments/assets/0916d7c9-2bfa-47ce-aec5-e19db8c4d54c)