### PR TITLE
Revert "Ignore `terraform` dependencies"

### DIFF
--- a/renovate/default-config.json5
+++ b/renovate/default-config.json5
@@ -12,9 +12,6 @@
   maven: {
     enabled: false,
   },
-  terraform: {
-    enabled: false,
-  },
   customDatasources: {
     "VUIIS-dax": {
       defaultRegistryUrlTemplate: "https://api.github.com/repos/VUIIS/dax/contents/misc/xnat-plugins",


### PR DESCRIPTION
Reverts UCL-MIRSG/.github#186
------
Discussed with @p-j-smith. Rather than ignoring globally, it makes more sense to only disable repos using the modules defined in https://github.com/UCL-ARC/terraform-harvester-modules. This stops things getting out of sync, but without increasing the workload of keeping dependencies up-to-date. See related PRs https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/pull/476, https://github.com/UCL-MIRSG/condenser-harvester-k3s-clusters/pull/61.