### PR TITLE
Disable `MD031` due to `markdownlint`/`prettier` clash

### DIFF
--- a/precommit/mirsg-hooks.yaml
+++ b/precommit/mirsg-hooks.yaml
@@ -91,6 +91,7 @@ repos:
       - id: markdownlint
         args:
           - --disable=MD013
+          - --disable=MD031
           - --disable=MD033
           - --dot
           - --fix


### PR DESCRIPTION
Not ideal, really, but this seems to be a recent `prettier` change. I'd rather not turn off `prettier` for Markdown, so this will have to do. Means we won't have linting clashes. See relevant issue https://github.com/prettier/prettier/issues/17652.