### PR TITLE
Add instructions for spellchecking with `typos`

### DIFF
--- a/precommit/README.md
+++ b/precommit/README.md
@@ -14,8 +14,8 @@ repos:
 Then run `pre-commit install; pre-commit autoupdate`.
 
 If a repository is experiencing spellchecking problems causes by
-[typos](https://github.com/crate-ci/typos) then one can create a `.typos.toml` file
-and fill it with the following:
+[typos](https://github.com/crate-ci/typos) then one can create a `.typos.toml`
+file and fill it with the following:
 
 ```toml
 [default]
@@ -27,6 +27,6 @@ extend-ignore-re = [
 ]
 ```
 
-One can then add, for example, ` # typos: ignore` on a given line, or
-`# typos: ignore-next-line` on a preceeding line. Note that this should work with any
-style of comment.
+One can then add, for example, `# typos: ignore` on a given line, or
+`# typos: ignore-next-line` on a preceeding line. Note that this should work
+with any style of comment.

--- a/precommit/README.md
+++ b/precommit/README.md
@@ -13,7 +13,7 @@ repos:
 
 Then run `pre-commit install; pre-commit autoupdate`.
 
-If a repository is experiencing spellchecking problems causes by
+If a repository is experiencing spellchecking problems caused by
 [typos](https://github.com/crate-ci/typos) then one can create a `.typos.toml`
 file and fill it with the following:
 

--- a/precommit/README.md
+++ b/precommit/README.md
@@ -12,3 +12,21 @@ repos:
 ```
 
 Then run `pre-commit install; pre-commit autoupdate`.
+
+If a repository is experiencing spellchecking problems causes by
+[typos](https://github.com/crate-ci/typos) then one can create a `.typos.toml` file
+and fill it with the following:
+
+```toml
+[default]
+extend-ignore-re = [
+    # Custom ignore regex patterns:
+    # https://github.com/crate-ci/typos/blob/master/docs/reference.md#example-configurations
+    ".*(?:#|--|//|/*).*(?:typos):\\s?ignore[^\\n]*\\n",
+    ".*(?:typos):\\s?ignore-next-line[^\\n]*\\n[^\\n]*",
+]
+```
+
+One can then add, for example, ` # typos: ignore` on a given line, or
+`# typos: ignore-next-line` on a preceeding line. Note that this should work with any
+style of comment.


### PR DESCRIPTION
This was created for https://github.com/UCL-ARC/terraform-harvester-modules/pull/32 and makes sense to re-use.