### PR TITLE
Update terraform_validate args in mirsg-hooks.yaml

### DIFF
--- a/prek/mirsg-hooks.yaml
+++ b/prek/mirsg-hooks.yaml
@@ -56,7 +56,7 @@ repos:
           - --args=-diff
       - id: terraform_validate
         args:
-          - --tf-init-args=-upgrade
+          - --tf-init-args=-lockfile=readonly
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0
     hooks:


### PR DESCRIPTION
Changes the args passed to `terraform init` by the `terraform_validate` hook to not update the Terraform lock file. With the current `-upgrade` arg, the call to `terraform init` attempts to update the lock file causing the hook to make modifications resulting in CI failures. Additionally, the update to the lock file is not muti-platform; our composite action now takes care of updating the lock file instead.