### PR TITLE
Revert tf-init-args for terraform_validate

### DIFF
--- a/prek/mirsg-hooks.yaml
+++ b/prek/mirsg-hooks.yaml
@@ -56,7 +56,7 @@ repos:
           - --args=-diff
       - id: terraform_validate
         args:
-          - --tf-init-args=-lockfile=readonly
+          - --tf-init-args=-upgrade
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0
     hooks:


### PR DESCRIPTION
Revert back to passing `-upgrade` to `tf-init-args` in `terraform_validate` hook.