### PR TITLE
Fix actions with `checkout` from other repo

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - uses: ./actions/links
         with:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - uses: ./actions/linting
         with:

--- a/.github/workflows/manage-projects.yaml
+++ b/.github/workflows/manage-projects.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - uses: ./actions/add-to-project
         with:

--- a/.github/workflows/safe-settings.yaml
+++ b/.github/workflows/safe-settings.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - name: Checkout GitHub Safe-Settings repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -26,6 +26,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
+          ref: ${{ github.ref }}
+          repository: ${{ github.repository }}
 
       - name: Bump version and push tag
         id: bump-version

--- a/actions/links/action.yml
+++ b/actions/links/action.yml
@@ -24,6 +24,8 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+        ref: ${{ github.ref }}
+        repository: ${{ github.repository }}
 
     - name: Generate token
       id: generate-token

--- a/actions/linting/action.yml
+++ b/actions/linting/action.yml
@@ -18,6 +18,8 @@ runs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+        ref: ${{ github.ref }}
+        repository: ${{ github.repository }}
 
     - name: Cache ansible & prek
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -34,6 +34,8 @@ runs:
       with:
         path: ${{ inputs.checkout_path }}
         persist-credentials: false
+        ref: ${{ github.ref }}
+        repository: ${{ github.repository }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/actions/terraform-docs/action.yml
+++ b/actions/terraform-docs/action.yml
@@ -33,6 +33,7 @@ runs:
       with:
         persist-credentials: true
         ref: ${{ github.head_ref || github.ref_name }}
+        repository: ${{ github.repository }}
         token: ${{ steps.generate-token.outputs.token }}
 
     - name: Render terraform docs and push changes back to PR

--- a/actions/terraform-lock-update/action.yml
+++ b/actions/terraform-lock-update/action.yml
@@ -26,6 +26,7 @@ runs:
       with:
         persist-credentials: true
         ref: ${{ github.head_ref || github.ref_name }}
+        repository: ${{ github.repository }}
         token: ${{ steps.generate-token.outputs.token }}
 
     - name: Setup terraform


### PR DESCRIPTION
This should make things more safe when using these composite actions in another repo
