### PR TITLE
Add tag ruleset to protect tags

### DIFF
--- a/safe-settings/suborgs/rulesets.yaml
+++ b/safe-settings/suborgs/rulesets.yaml
@@ -69,3 +69,17 @@ rulesets:
             - context: linting
               integration_id: 15368
           strict_required_status_checks_policy: false
+
+  - name: Tags
+    target: tag
+    enforcement: active
+
+    conditions:
+      ref_name:
+        include:
+          - ~ALL
+        exclude: []
+
+    rules:
+      - type: deletion
+      - type: non_fast_forward # prevents force pushes


### PR DESCRIPTION
Following on the incident identified in https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/issues/526 where some history rewriting changed the hashes of some tags. This new ruleset will prevent the force pushing and deletion of tags across all repositories.
