### PR TITLE
Bump pre-commit hooks and add python_version input to action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.246.0
+    rev: v0.250.0
     hooks:
       - id: mirsg-hooks
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 43.102.4
+    rev: 43.257.5
     hooks:
       - id: renovate-config-validator
         args:

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -67,4 +67,13 @@ command is required, then use the `molecule_command` argument, i.e.
 `molecule_command: converge`.
 
 If a specific Python version is required, use the `python_version` argument,
-i.e. `python_version: "3.12"`. The default is `"3.14"`.
+i.e. `python_version: "3.12"`. This overrides the Python version uv uses.
+
+If `python_version` is not provided, [uv](https://docs.astral.sh/uv/) discovers
+a Python version as follows:
+
+1. A `.python-version` file in the repository, if present
+2. The `requires-python` field in `pyproject.toml`, if present
+3. An existing Python installation on the runner (e.g. the system Python on
+   GitHub-hosted runners)
+4. Failing all of the above, uv downloads the latest stable Python version

--- a/actions/molecule-test/README.md
+++ b/actions/molecule-test/README.md
@@ -65,3 +65,6 @@ If one requires a specific version of Ansible, then use the
 By default, the action will default to `molecule test`, if running a specific
 command is required, then use the `molecule_command` argument, i.e.
 `molecule_command: converge`.
+
+If a specific Python version is required, use the `python_version` argument,
+i.e. `python_version: "3.12"`. The default is `"3.14"`.

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -26,8 +26,8 @@ inputs:
     description: Command to run with molecule
     default: test
   python_version:
-    description: Python version to use
-    default: "3.14"
+    description: Python version to use (optional)
+    required: false
 
 runs:
   using: composite

--- a/actions/molecule-test/action.yml
+++ b/actions/molecule-test/action.yml
@@ -25,6 +25,9 @@ inputs:
   molecule_command:
     description: Command to run with molecule
     default: test
+  python_version:
+    description: Python version to use
+    default: "3.14"
 
 runs:
   using: composite
@@ -41,7 +44,7 @@ runs:
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         activate-environment: true
-        python-version: 3.14
+        python-version: ${{ inputs.python_version }}
 
     - name: Install dependencies
       shell: bash

--- a/safe-settings/README.md
+++ b/safe-settings/README.md
@@ -56,4 +56,4 @@ suborgrepos:
 ```
 
 at the top of the file. Further explanation can be found in the
-[Safe-Settings issues](https://github.com/github/safe-settings/issues/553#issuecomment-2552578978).
+[Safe-Settings issues](https://github.com/github-community-projects/safe-settings/issues/553#issuecomment-2552578978).


### PR DESCRIPTION
This pull request updates the pre-commit hooks and adds support for specifying a Python version in the `molecule-test` GitHub Action in order to address issues in https://github.com/UCL-MIRSG/ansible-collection-infra/pull/222