### PR TITLE
fix: Use upgrade option when initialising terraform

### DIFF
--- a/actions/terraform-lock-update/action.yml
+++ b/actions/terraform-lock-update/action.yml
@@ -38,7 +38,7 @@ runs:
         find . -name ".terraform.lock.hcl" -print0 | while IFS= read -r -d '' lockfile; do
           dir=$(dirname "$lockfile")
           echo "Initialising $dir"
-          terraform -chdir="$dir" init -backend=false
+          terraform -chdir="$dir" init -backend=false -upgrade
           echo "Locking providers in $dir"
           terraform -chdir="$dir" providers lock \
             -platform=darwin_amd64 \


### PR DESCRIPTION
This PR adds the `-upgrade` command line option when calling `terraform init` in the `terraform-lock-update` action. Without this `terraform init` never makes any changes to the lock file.